### PR TITLE
Update `Get()` to use options pattern.

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -63,12 +64,24 @@ func Get(conf any, options ...SetupOption) error {
 		option(&opts)
 	}
 
-	viper.SetConfigName(opts.configName)
-	viper.SetConfigType(opts.configType)
-	viper.AddConfigPath(opts.configAbsPath)
+	vpr := viper.New()
 
-	viper.SetEnvPrefix(opts.envPrefix)
-	viper.AutomaticEnv()
+	vpr.SetConfigName(opts.configName)
+
+	// If config type is not set, attempt to assume it from the configName
+	if opts.configType == "" {
+		ext := filepath.Ext(opts.configName)
+		if len(ext) > 1 {
+			vpr.SetConfigType(ext[1:])
+		}
+	} else {
+		vpr.SetConfigType(opts.configType)
+	}
+
+	vpr.AddConfigPath(opts.configAbsPath)
+
+	vpr.SetEnvPrefix(opts.envPrefix)
+	vpr.AutomaticEnv()
 
 	if opts.defaults != nil {
 		var defaults map[string]interface{}
@@ -76,12 +89,12 @@ func Get(conf any, options ...SetupOption) error {
 			return err
 		}
 		for k, v := range defaults {
-			viper.SetDefault(k, v)
+			vpr.SetDefault(k, v)
 		}
 	}
 
 	if opts.saveIfNotExists {
-		saveErr := viper.SafeWriteConfig()
+		saveErr := vpr.SafeWriteConfig()
 		var configFileAlreadyExistsError viper.ConfigFileAlreadyExistsError
 		if errors.As(saveErr, &configFileAlreadyExistsError) {
 			// bc the option is "save if not exists", we can ignore this error
@@ -90,14 +103,14 @@ func Get(conf any, options ...SetupOption) error {
 		}
 	}
 
-	readError := viper.ReadInConfig()
+	readError := vpr.ReadInConfig()
 	var fileNotFoundErr viper.ConfigFileNotFoundError
 	if readError != nil && errors.As(readError, &fileNotFoundErr) && readError.Error() != fileNotFoundErr.Error() {
 		// return the error if the error is not a ConfigFileNotFoundError
 		return readError
 	}
 
-	unmarshalErr := viper.Unmarshal(&conf)
+	unmarshalErr := vpr.Unmarshal(&conf)
 	if unmarshalErr != nil {
 		return unmarshalErr
 	}

--- a/configure_test.go
+++ b/configure_test.go
@@ -31,15 +31,14 @@ func TestDefaults(t *testing.T) {
 	}
 }
 
-func TestFromEnv(t *testing.T) {
+func TestFromEnvUsingDefaultPrefix(t *testing.T) {
 	type Config struct {
 		Secret string `mapstructure:"app_secret"`
 	}
 
 	key := "APP_SECRET"
-	_ = os.Unsetenv(key)
 	expected := "987xyz"
-	_ = os.Setenv(key, expected)
+	defer setEnvValue(t, key, expected)()
 
 	conf := &Config{}
 
@@ -48,7 +47,6 @@ func TestFromEnv(t *testing.T) {
 		configure.WithDefaultConfig(Config{
 			Secret: "abc123",
 		}),
-		configure.WithEnvPrefix(""),
 	)
 
 	if err != nil {
@@ -64,13 +62,12 @@ func TestFromEnv(t *testing.T) {
 
 func TestFromEnvWithPrefix(t *testing.T) {
 	type Config struct {
-		Secret string `mapstructure:"foo_secret"`
+		Secret string `mapstructure:"secret"`
 	}
 
 	key := "FOO_SECRET"
-	_ = os.Unsetenv(key)
 	expected := "987xyz"
-	_ = os.Setenv(key, expected)
+	defer setEnvValue(t, key, expected)()
 
 	conf := &Config{}
 
@@ -89,39 +86,6 @@ func TestFromEnvWithPrefix(t *testing.T) {
 	if conf.Secret != expected {
 		t.Errorf("expected %s, got %s", expected, conf.Secret)
 	}
-
-	_ = os.Unsetenv(key)
-}
-
-func TestFromEnvWithNoEnvPrefix(t *testing.T) {
-	type Config struct {
-		AnotherSecret string `mapstructure:"another_secret"`
-	}
-
-	key := "APP_ANOTHER_SECRET"
-	_ = os.Unsetenv(key)
-	expected := "987xyz"
-	_ = os.Setenv(key, expected)
-
-	conf := &Config{}
-
-	err := configure.Get(
-		conf,
-		configure.WithDefaultConfig(Config{
-			AnotherSecret: "abc123",
-		}),
-		configure.WithEnvPrefix("APP"),
-	)
-
-	if err != nil {
-		t.Fatalf("error setting up config: %v", err)
-	}
-
-	if conf.AnotherSecret != expected {
-		t.Errorf("expected %s, got %s", expected, conf.AnotherSecret)
-	}
-
-	_ = os.Unsetenv(key)
 }
 
 func TestFromFile(t *testing.T) {
@@ -178,5 +142,24 @@ func TestFromFileUsingConfigNameOnly(t *testing.T) {
 	expected := "foo foo foo"
 	if conf.SomeValue != expected {
 		t.Errorf("expected %s, got %s", expected, conf.SomeValue)
+	}
+}
+
+func setEnvValue(t *testing.T, key, value string) func() {
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("error unsetting env var for testing: %v", err)
+	}
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("error unsetting env var for testing: %v", err)
+	}
+	actual := os.Getenv(key)
+	if os.Getenv(key) != value {
+		t.Fatalf("error unsetting env var for testing: expected %s, got %s", value, actual)
+	}
+
+	return func() {
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("error unsetting env var for testing: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
This PR updates the `config.Get()` function to use options pattern. This pattern allows us to expand and add new options without causing breaking changes in the future.