### PR TITLE
change New() return type to *Configure

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -82,8 +82,8 @@ func (c *Configure) checkFrozen(cb func()) error {
 }
 
 // New returns a new instance of Configure with defaults set.
-func New() Configure {
-	return Configure{
+func New() *Configure {
+	return &Configure{
 		writeIfNotExists: false,
 	}
 }


### PR DESCRIPTION
Changes `New()` to return `*Configure` instead of `Configure` to make the returned value more ergonomic to use and consistent with Go conventions for mutable structs.